### PR TITLE
Binary data properly encoded in sendWorkData

### DIFF
--- a/lib/gearmanode/worker.js
+++ b/lib/gearmanode/worker.js
@@ -319,7 +319,10 @@ common.mixin({
         data = data || '';
         var jobServer = this.clientOrWorker._getJobServerByUid(this.jobServerUid);
         Worker.logger.log('debug', 'work data, handle=%s, data=%s', this.handle, data.toString());
-        jobServer.send(protocol.encodePacket(protocol.PACKET_TYPES.WORK_DATA, null, [this.handle, data.toString()]));
+        if (data.constructor.name !== 'Buffer') {
+            data = data.toString();
+        }
+        jobServer.send(protocol.encodePacket(protocol.PACKET_TYPES.WORK_DATA, null, [this.handle, data]));
     },
     /**
      * This is sent to update the server (and any listening clients) of the status of a running job.


### PR DESCRIPTION
Building on your patches I took the code contributed by @chulsupark and added it to sendWorkData so that partial Binary responses will be encoded properly.